### PR TITLE
GitHub PagesでもRESAS APIが使用できるように修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Set environment variables
+        run: echo "VITE_RESAS_API_KEY=${{ secrets.VITE_RESAS_API_KEY }}" >> $GITHUB_ENV
+
       - name: Build the project
         run: npm run build
 


### PR DESCRIPTION
## 対応内容
- GitHub Actions実行時、RESAS APIのAPIキーを GitHub Secrets経由で渡すように修正

## 妥協点
- この API キーはフロントエンドからのリクエストで直接使用されますが、RESAS API自体が誰でも登録して利用できるAPI であり、秘匿情報を含まないため、露出しても問題ないと判断

